### PR TITLE
Fix the req and add auto-build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
           echo D | xcopy assets dist\assets /e
       - uses: actions/upload-artifact@v3
         with:
-          name: bot-artifact
+          name: Rainbow-Six-Auto-Renown-Farm-For-Windows
           path: dist
-      
-
-
+          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: PyInstaller-Windows
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+    
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - name: Install requirements and installer
+        run: |
+          pip install -r requirements.txt
+          pip install pyinstaller
+      - name: Run pyinstaller
+        run: |
+          python -m PyInstaller -F bot.py
+          echo D | xcopy assets dist\assets /e
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bot-artifact
+          path: dist
+      
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pyautogui
-pydirectinput
-pynput
-colorama
-Pillow
+colorama~=0.4.4
+PyAutoGUI~=0.9.53
+PyDirectInput~=1.0.4
+pynput~=1.7.6
+Pillow~=9.0.1
+opencv_python~=4.6.0.66


### PR DESCRIPTION
In `pyautogui.locateOnScreen('x.png', confidence=0.6):` 
The confidence parameter is a OpenCV feature, use this parameter we need OpenCV installed.

And I use github action to build exe file for windows users that they won't need to set python.